### PR TITLE
Remove BUILD_DYNRT_LIBS, install missing headers and export cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@
 # constants to the machine in which is run.
 # The following options (default off) control what is built:
 # BUILD_CPP to build the cpp wrapper to the ASL library
-# BUILD_DYNRT_LIBS to build the libraries linked against the dynamic runtime
 # BUILD_MT_LIBS to build the multithreaded libraries 
 project(ASL)
 cmake_minimum_required(VERSION 2.8)
@@ -18,9 +17,6 @@ set(AMPL_CMAKE_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/support/cmake)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${AMPL_CMAKE_MODULE_DIR})
 if(NOT BUILD_MCMODELLARGE)
   option(BUILD_MCMODELLARGE "Build the library linked with mcmodel=large flag, used for compiling lgo" OFF)
-endif()
-if(NOT BUILD_DYNRT_LIBS)
-  option(BUILD_DYNRT_LIBS "Build the libraries linked against the dynamic runtime (windows only)" OFF)
 endif()
 if(NOT BUILD_MT_LIBS)
   option(BUILD_MT_LIBS "Build the multithreaded library" OFF)
@@ -247,8 +243,9 @@ endif()
 
 macro(createSingleASL name sourcedir sources)
   add_library(${name} STATIC ${${sources}} ${GENERATED_INCLUDE_DIR}/arith.h)
-  target_include_directories(${name} PUBLIC ${GENERATED_INCLUDE_DIR}
-                                            ${sourcedir})
+  target_include_directories(${name} PUBLIC $<BUILD_INTERFACE:${GENERATED_INCLUDE_DIR}>
+                                            $<BUILD_INTERFACE:${sourcedir}>
+                                            $<INSTALL_INTERFACE:include>)
   target_compile_definitions(${name} PRIVATE ${ASL_COMPILE_DEFINITIONS})
   target_link_libraries(${name} PUBLIC ${CMAKE_DL_LIBS})
   if(NOT WIN32)
@@ -256,7 +253,7 @@ macro(createSingleASL name sourcedir sources)
   endif()
   if(MSVC)
     target_compile_options(${name} PRIVATE 
-      /wd4013 /wd4018 /wd4101 /wd4244 /wd4273 /wd4267 /wd4996 /MT$<$<CONFIG:Debug>:d>)
+      /wd4013 /wd4018 /wd4101 /wd4244 /wd4273 /wd4267 /wd4996)
   else()
     target_compile_options(${name} PRIVATE -Wno-unused-result -Wno-parentheses)
   endif()
@@ -289,14 +286,6 @@ if(BUILD_MT_LIBS)
   endif()
 endif()
 
-
-if(MSVC AND BUILD_DYNRT_LIBS)
-  # Create ASLs linked to dynamic runtime on windows
-  createSingleASL(asl-dynrt ${ASL_SOURCE_DIR} ASL_SOURCES)
-  target_compile_options(asl-dynrt PUBLIC /MD$<$<CONFIG:Debug>:d>)
-  createSingleASL(asl2-dynrt ${ASL2_SOURCE_DIR} ASL2_SOURCES)
-  target_compile_options(asl2-dynrt PUBLIC /MD$<$<CONFIG:Debug>:d>)
-endif()
 if(BUILD_MCMODELLARGE)
  createSingleASL(asl2-large ${ASL2_SOURCE_DIR} ASL2_SOURCES)
  if(${ARCH} EQUAL 64)
@@ -317,18 +306,18 @@ if(BUILD_CPP)
 endif()
 
 install(FILES ${ASL_HEADERS} ${ASL_SOURCE_DIR}/opcode.hd ${ASL_SOURCE_DIR}/r_opn.hd 
+    ${GENERATED_INCLUDE_DIR}/stdio1.h ${GENERATED_INCLUDE_DIR}/arith.h
     DESTINATION include/asl  COMPONENT asl) 
 install(FILES ${ASL2_HEADERS} ${ASL2_SOURCE_DIR}/opcode.hd ${ASL2_SOURCE_DIR}/r_opn.hd 
         DESTINATION include/asl2  COMPONENT asl) 
 
-install(TARGETS asl asl2 DESTINATION lib COMPONENT asl)
+install(TARGETS asl asl2 EXPORT ampl-asl-config DESTINATION lib COMPONENT asl)
 if(BUILD_MT_LIBS)
-  install(TARGETS asl-mt asl2-mt DESTINATION lib COMPONENT asl)
-endif()
-if(MSVC AND BUILD_DYNRT_LIBS)
-  install(TARGETS asl-dynrt asl2-dynrt DESTINATION lib COMPONENT asl)
+  install(TARGETS asl-mt asl2-mt EXPORT ampl-asl-config DESTINATION lib COMPONENT asl)
 endif()
 if(TARGET aslcpp)
     install(FILES ${ASL_CPP_HEADERS} DESTINATION include/aslcpp  COMPONENT asl) 
-    install(TARGETS aslcpp DESTINATION lib  COMPONENT asl)
+    install(TARGETS aslcpp EXPORT ampl-asl-config DESTINATION lib  COMPONENT asl)
 endif()
+
+install(EXPORT ampl-asl-config DESTINATION share/ampl-asl)


### PR DESCRIPTION
1. CRT linkage should follow the `C_FLAGS`/`CXX_FLAGS` setting instead of specifying it through options, so I deleted `BUILD_DYNRT_LIBS`.
2. The exported files `stdio1.h` and `arith.h` are not installed.
3. Export cmake targets so we can easily to use this library using `find_package(ampl-asl CONFIG)` / `target_link_libraries(main PRIVATE ampl-asl)`.