### PR TITLE
Silence a warning when building with LTO

### DIFF
--- a/src/solvers/fgh_read.c
+++ b/src/solvers/fgh_read.c
@@ -98,7 +98,8 @@ sorry_CLP(EdRead *R, const char *what)
 #define memadj(x) (((x) + (sizeof(long)-1)) & ~(sizeof(long)-1))
 #endif
 
- extern efunc f_OPPLTERM, f_OPHOL, f_OPVARVAL, f_OPFUNCALL;
+ extern efunc f_OPPLTERM, f_OPVARVAL, f_OPFUNCALL;
+ extern char *f_OPHOL(expr *e A_ASL);
  extern sfunc f_OPIFSYM;
 
  static void
@@ -280,7 +281,7 @@ eread(EdRead *R, int deriv)
 			k = ks = symargs = numargs = 0;
 			while(args < argse) {
 				arg = *args++ = eread(R, deriv);
-				if ((op = arg->op) == f_OPHOL)
+				if ((op = arg->op) == (efunc *)f_OPHOL)
 					symargs++;
 				else if (op == (efunc*)f_OPIFSYM)
 					ks++;
@@ -339,7 +340,7 @@ eread(EdRead *R, int deriv)
 			nn = nn0 = (int *)b;
 			for(args = rvf->args; args < argse; at++) {
 				arg = *args++;
-				if ((op = arg->op) == f_OPHOL) {
+				if ((op = arg->op) == (efunc *)f_OPHOL) {
 					*at = --symargs;
 					*sa++ = ((expr_h *)arg)->sym;
 					}
@@ -1348,7 +1349,7 @@ aholread(EdRead *R)
 		*s1++ = k;
 		}
 	*s1 = 0;
-	rvh->op = f_OPHOL;
+	rvh->op = (efunc *)f_OPHOL;
 	rvh->a = nv1;
 	return (expr *)rvh;
 	}
@@ -1367,7 +1368,7 @@ bholread(EdRead *R)
 	if (fread(s, i, 1, R->nl) != 1)
 		badline(R);
 	s[i] = 0;
-	rvh->op = f_OPHOL;
+	rvh->op = (efunc *)f_OPHOL;
 	rvh->a = nv1;
 	for(;;) switch(*s++) {
 			case 0: goto break2; /* so we return at end of fcn */


### PR DESCRIPTION
When building with LTO (link-time optimization), GCC complains:
```
/builddir/build/BUILD/asl-b6d60a4a53261e220fca22bd37aa48ac99107dc1/src/solvers/fgh_read.c:101:27: warning: type of 'f2_HOL_ASL' does not match original declaration [-Wlto-type-mismatch]
  101 |  extern efunc f_OPPLTERM, f_OPHOL, f_OPVARVAL, f_OPFUNCALL;
      |                           ^
/builddir/build/BUILD/asl-b6d60a4a53261e220fca22bd37aa48ac99107dc1/src/solvers/rops2.c:1019:1: note: return value type mismatch
 1019 | f_OPHOL(expr *e A_ASL)
      | ^
/builddir/build/BUILD/asl-b6d60a4a53261e220fca22bd37aa48ac99107dc1/src/solvers/rops2.c:1019:1: note: 'f2_HOL_ASL' was previously declared here
/builddir/build/BUILD/asl-b6d60a4a53261e220fca22bd37aa48ac99107dc1/src/solvers/rops2.c:1019:1: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```

This PR addresses the issue by making the declarations of `f_OPHOL` match, and casting as necessary.  This avoids the need for `-fno-strict-aliasing`, which unnecessarily pessimizes the code.
