### PR TITLE
Define _GNU_SOURCE when including fenv.h

### DIFF
--- a/src/solvers/fpinit.c
+++ b/src/solvers/fpinit.c
@@ -49,7 +49,8 @@ int isatty_ASL; /* for use with "sw" under NT */
 #undef WIN32
 #define WIN32
 #else
-#include "fenv.h"
+#define _GNU_SOURCE
+#include <fenv.h>
 #endif
 
 #ifdef WIN32

--- a/src/solvers2/fpinit.c
+++ b/src/solvers2/fpinit.c
@@ -49,7 +49,8 @@ int isatty_ASL; /* for use with "sw" under NT */
 #undef WIN32
 #define WIN32
 #else
-#include "fenv.h"
+#define _GNU_SOURCE
+#include <fenv.h>
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
Fedora has 2 architectures, ppc64le and s390x, where fedisableexcept is needed.  However, with glibc 2.37 at least, the fedisableexcept prototype is visible only if `_GNU_SOURCE` is defined.  This is remarked on in the "glibc notes" section of the fedisableexcept man page on Linux systems.

Also, since fenv.h is a system header file rather than a local header file, use angle brackets with `#include` instead of quotes.
