### PR TITLE
solvers: Fix incorrect f_OPHOL declaration

### DIFF
--- a/src/solvers/fgh_read.c
+++ b/src/solvers/fgh_read.c
@@ -98,7 +98,7 @@ sorry_CLP(EdRead *R, const char *what)
 #define memadj(x) (((x) + (sizeof(long)-1)) & ~(sizeof(long)-1))
 #endif
 
- extern char* f_OPHOL;
+ extern char *f_OPHOL ANSI((expr *e));
  extern efunc f_OPPLTERM, f_OPVARVAL, f_OPFUNCALL;
  extern sfunc f_OPIFSYM;
 


### PR DESCRIPTION
https://github.com/gentoo/gentoo/pull/39303
https://github.com/coin-or-tools/ThirdParty-ASL/issues/8

This change fixes the following issue with LTO:

```
solvers/fgh_read.c:101:15: error: function 'f2_HOL_ASL' redeclared as variable
  101 |  extern char* f_OPHOL;
      |               ^
solvers/rops2.c:1019:1: note: previously declared here
 1019 | f_OPHOL(expr *e A_ASL)
      | ^
lto1: fatal error: errors during merging of translation units
compilation terminated.
```