### PR TITLE
Fixed directory to which `arith.h` gets written

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(CMAKE_CROSSCOMPILING AND CMAKE_SYSTEM_PROCESSOR MATCHES "^x86")
     set(ARITH_H "${ARITH_H}/* sizeof(size_t) = ${SIZE_T_SIZE}")
     set(ARITH_H "${ARITH_H} but sizeof(ssize_t) = ${SSIZE_T_SIZE} */\n")
   endif()
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/arith.h
+  file(WRITE ${GENERATED_INCLUDE_DIR}/arith.h
        "${ARITH_H}#define QNaN0 0x0\n#define QNaN1 0xfff80000\n")
 else()
   if(NOT WIN32)


### PR DESCRIPTION
Hi,
I'm trying to cross-compile `solvers2` on [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/pull/13950) and I realized that `arith.h` gets written to the wrong directory (`${CMAKE_CURRENT_BINARY_DIR}` instead of `${GENERATED_INCLUDE_DIR}`).

How to reproduce the error:
```cmake
# xtool.cmake
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR x86_64)
set(CMAKE_C_COMPILER cc)
set(CMAKE_CXX_COMPILER c++)
```
then
```
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=xtool.cmake -DBUILD_SHARED_LIBS=ON
```
We get the following error message:
```
  Cannot find source file:

    .../asl/build/include/arith.h
```