### PR TITLE
Detect aarch64 and stop emitting AIX-only `-maix64` on non-AIX targets

### DIFF
--- a/support/cmake/setArchitecture.cmake
+++ b/support/cmake/setArchitecture.cmake
@@ -8,9 +8,7 @@
 
 set(archdetect_c_code
     "
-#if defined(__aarch64__) || defined(_M_ARM64)
-    #error cmake_ARCH arm64
-#elif defined(__arm__) || defined(__TARGET_ARCH_ARM)
+#if defined(__arm__) || defined(__TARGET_ARCH_ARM)
     #if defined(__ARM_ARCH_7__) \\
         || defined(__ARM_ARCH_7A__) \\
         || defined(__ARM_ARCH_7R__) \\
@@ -150,8 +148,8 @@ function(getArchitectureFlags ARCH COMPILE_FLAGS LINK_FLAGS)
   if(NOT ((ARCH EQUAL 32) OR (ARCH EQUAL 64)))
     message(ERROR_CRITICAL "Please define the architecture")
   endif()
-  if(UNIX AND NOT CPUARCH MATCHES "arm")
-    if(CPUARCH MATCHES "ppc64" AND CMAKE_SYSTEM_NAME STREQUAL "AIX") # on AIX
+  if(UNIX AND (CPUARCH MATCHES "^(i386|x86_64)$" OR (CPUARCH MATCHES "ppc64" AND CMAKE_SYSTEM_NAME STREQUAL "AIX")))
+    if(CPUARCH MATCHES "ppc64") # on AIX
       if(ARCH EQUAL 32)
         set(CCFLAG "")
       elseif(ARCH EQUAL 64)

--- a/support/cmake/setArchitecture.cmake
+++ b/support/cmake/setArchitecture.cmake
@@ -8,7 +8,9 @@
 
 set(archdetect_c_code
     "
-#if defined(__arm__) || defined(__TARGET_ARCH_ARM)
+#if defined(__aarch64__) || defined(_M_ARM64)
+    #error cmake_ARCH arm64
+#elif defined(__arm__) || defined(__TARGET_ARCH_ARM)
     #if defined(__ARM_ARCH_7__) \\
         || defined(__ARM_ARCH_7A__) \\
         || defined(__ARM_ARCH_7R__) \\
@@ -149,7 +151,7 @@ function(getArchitectureFlags ARCH COMPILE_FLAGS LINK_FLAGS)
     message(ERROR_CRITICAL "Please define the architecture")
   endif()
   if(UNIX AND NOT CPUARCH MATCHES "arm")
-    if(CPUARCH MATCHES "ppc64") # on AIX
+    if(CPUARCH MATCHES "ppc64" AND CMAKE_SYSTEM_NAME STREQUAL "AIX") # on AIX
       if(ARCH EQUAL 32)
         set(CCFLAG "")
       elseif(ARCH EQUAL 64)


### PR DESCRIPTION
How to reproduce the error:

```bash
# 1. aarch64 cross-compiler (Debian/Ubuntu)
sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu cmake

# 2. minimal aarch64 cross toolchain file
cat > aarch64.cmake <<'EOF'
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR aarch64)
set(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc)
set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
EOF

# 3. configure + build
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=aarch64.cmake -DBUILD_SHARED_LIBS=ON
cmake --build build --target asl2
```
The error reads:
```
aarch64-linux-gnu-gcc: error: unrecognized command-line option ‘-m64’
```

See https://github.com/JuliaPackaging/Yggdrasil/pull/13950