### PR TITLE
Use `S_ISDIR()`/`S_ISREG()` instead of `S_IFDIR`/`S_IFREG`

### DIFF
--- a/src/solvers/funcadd1.c
+++ b/src/solvers/funcadd1.c
@@ -118,9 +118,9 @@ file_kind(const char *name) /* 1 == regular file, 2 ==> directory; else 0 */
 
 	if (stat(name,&sb))
 		return 0;
-	if (sb.st_mode & S_IFDIR)
+	if (S_ISDIR(sb.st_mode))
 		return 2;
-	if (sb.st_mode & S_IFREG)
+	if (S_ISREG(sb.st_mode))
 		return 1;
 	return 0;
 	}

--- a/src/solvers2/funcadd1.c
+++ b/src/solvers2/funcadd1.c
@@ -118,9 +118,9 @@ file_kind(const char *name) /* 1 == regular file, 2 ==> directory; else 0 */
 
 	if (stat(name,&sb))
 		return 0;
-	if (sb.st_mode & S_IFDIR)
+	if (S_ISDIR(sb.st_mode))
 		return 2;
-	if (sb.st_mode & S_IFREG)
+	if (S_ISREG(sb.st_mode))
 		return 1;
 	return 0;
 	}


### PR DESCRIPTION
`file_kind()` tests file type with the raw `S_IFDIR`/`S_IFREG` constants. On FreeBSD those constants are declared only under `#if __XSI_VISIBLE` in `<sys/stat.h>`, whereas the `S_ISDIR()`/`S_ISREG()` macros are defined unconditionally.

How to reproduce the error:
```c
// fk.c
#include <sys/types.h>
#include <sys/stat.h>

static int file_kind(const char* name) {
    struct stat sb;
    if (stat(name,&sb)) return 0;
    if (sb.st_mode & S_IFDIR) return 2;   // raw constant
    if (sb.st_mode & S_IFREG) return 1;
    return 0;
}

int main(void) {
  return file_kind(".");
}
```
then:
```
clang -std=c99 -D_POSIX_C_SOURCE=200809L fk.c -o /dev/null
# fk.c:6:22: error: use of undeclared identifier 'S_IFDIR'
# fk.c:7:22: error: use of undeclared identifier 'S_IFREG'
```

See https://github.com/JuliaPackaging/Yggdrasil/pull/13950